### PR TITLE
fixed routes not showing components view properly

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,7 +28,6 @@ const routes = [
   { path: '/dashboard/components', name: 'components', component: ComponentsView },
   { path: '/dashboard/users', name: 'users', component: IndexView },
   { path: '/dashboard/log', name: 'computers-status-log', component: IndexView },
-  { path: '/dashboard/components', name: 'components', component: IndexView },
   { path: '/dashboard/reports', name: 'reports', component: IndexView },
   { path: '/dashboard/inventory', name: 'inventory', component: IndexView },
 


### PR DESCRIPTION
This pull request makes a small adjustment to the routing configuration in `src/router/index.ts` by removing a duplicate route definition for `/dashboard/components`. This helps prevent potential routing conflicts and ensures the route is handled consistently.

* Removed duplicate route definition for `/dashboard/components` in `src/router/index.ts` to avoid conflicts and ensure proper routing behavior.