### PR TITLE
feat(api): protect routes with JWT and admin guards

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -4,27 +4,28 @@
 // Third-Party Imports
 // -------------------------------
 import { JwtModule } from '@nestjs/jwt';
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UsersModule } from '@users/users.module';
 
 // -------------------------------
 // Own Imports
 // -------------------------------
 import { AuthController } from './auth.controller';
+import { AuthGuard } from './guards/auth.guard';
 import { AuthService } from './auth.service';
 import { JWT_SECRET } from '@auth/constants';
 
 @Module({
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, AuthGuard],
   imports: [
-    UsersModule,
+    forwardRef(() => UsersModule),
     JwtModule.register({
       global: true,
       secret: JWT_SECRET,
       signOptions: { expiresIn: '1h' },
     }),
   ],
-  exports: [AuthService],
+  exports: [AuthService, AuthGuard],
 })
 export class AuthModule {}

--- a/backend/src/components/components.controller.ts
+++ b/backend/src/components/components.controller.ts
@@ -3,6 +3,8 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AdminRoleGuard } from '@users/guards/admin-role.guard';
+import { AuthGuard } from '@/auth/guards/auth.guard';
 import { CreateComponentDto } from '@components/dtos/create-component.dto';
 import { UpdateComponentDto } from '@components/dtos/update-component.dto';
 import { Component } from '@components/entities/component.entity';
@@ -21,9 +23,11 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 
 @Controller('components')
+@UseGuards(AuthGuard)
 export class ComponentsController {
   constructor(private readonly componentsService: ComponentsService) {}
 
@@ -33,6 +37,7 @@ export class ComponentsController {
   }
 
   @Post()
+  @UseGuards(AdminRoleGuard)
   create(@Body() createComponentDto: CreateComponentDto): Promise<Component> {
     return this.componentsService.create(createComponentDto);
   }
@@ -43,6 +48,7 @@ export class ComponentsController {
   }
 
   @Patch(':id')
+  @UseGuards(AdminRoleGuard)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateComponentDto: UpdateComponentDto,
@@ -52,6 +58,7 @@ export class ComponentsController {
 
   @Delete(':id')
   @HttpCode(204)
+  @UseGuards(AdminRoleGuard)
   delete(@Param('id', ParseIntPipe) id: number): Promise<void> {
     return this.componentsService.delete(id);
   }

--- a/backend/src/components/components.module.ts
+++ b/backend/src/components/components.module.ts
@@ -3,9 +3,11 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AuthModule } from '@/auth/auth.module';
 import { Component } from '@components/entities/component.entity';
 import { ComponentsController } from '@components/components.controller';
 import { ComponentsService } from '@components/components.service';
+import { UsersModule } from '@users/users.module';
 
 // -------------------------------
 // Third-Party Imports
@@ -14,7 +16,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Component])],
+  imports: [TypeOrmModule.forFeature([Component]), UsersModule, AuthModule],
   controllers: [ComponentsController],
   providers: [ComponentsService],
   exports: [ComponentsService],

--- a/backend/src/computers-history/computers-history.controller.ts
+++ b/backend/src/computers-history/computers-history.controller.ts
@@ -3,6 +3,8 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AdminRoleGuard } from '@users/guards/admin-role.guard';
+import { AuthGuard } from '@/auth/guards/auth.guard';
 import { ComputersHistoryService } from '@computers-history/computers-history.service';
 import { CreateComputerStatusHistoryDto } from '@computers-history/dto/create-computer-status-history.dto';
 
@@ -16,15 +18,18 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 
 @Controller('computers-history')
+@UseGuards(AuthGuard)
 export class ComputersHistoryController {
   constructor(
     private readonly computersHistoryService: ComputersHistoryService,
   ) {}
 
   @Post()
+  @UseGuards(AdminRoleGuard)
   create(@Body() dto: CreateComputerStatusHistoryDto) {
     return this.computersHistoryService.create(dto);
   }

--- a/backend/src/computers-history/computers-history.module.ts
+++ b/backend/src/computers-history/computers-history.module.ts
@@ -3,9 +3,11 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AuthModule } from '@/auth/auth.module';
 import { ComputersHistoryController } from '@computers-history/computers-history.controller';
 import { ComputerStatusHistory } from '@computers-history/entities/computer-status-history.entity';
 import { ComputersHistoryService } from '@computers-history/computers-history.service';
+import { UsersModule } from '@users/users.module';
 
 // -------------------------------
 // Third-Party Imports
@@ -14,7 +16,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ComputerStatusHistory])],
+  imports: [
+    TypeOrmModule.forFeature([ComputerStatusHistory]),
+    UsersModule,
+    AuthModule,
+  ],
   controllers: [ComputersHistoryController],
   providers: [ComputersHistoryService],
 })

--- a/backend/src/computers/computers.controller.ts
+++ b/backend/src/computers/computers.controller.ts
@@ -3,6 +3,8 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AdminRoleGuard } from '@users/guards/admin-role.guard';
+import { AuthGuard } from '@/auth/guards/auth.guard';
 import { ComputersService } from '@computers/computers.service';
 import { CreateComputerDto } from '@computers/dto/create-computer.dto';
 import { UpdateComputerDto } from '@computers/dto/update-computer.dto';
@@ -20,13 +22,16 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 
 @Controller('computers')
+@UseGuards(AuthGuard)
 export class ComputersController {
   constructor(private readonly computersService: ComputersService) {}
 
   @Post()
+  @UseGuards(AdminRoleGuard)
   create(@Body() createComputerDto: CreateComputerDto) {
     return this.computersService.create(createComputerDto);
   }
@@ -54,6 +59,7 @@ export class ComputersController {
   }
 
   @Patch(':id')
+  @UseGuards(AdminRoleGuard)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateComputerDto: UpdateComputerDto,
@@ -62,6 +68,7 @@ export class ComputersController {
   }
 
   @Delete(':id')
+  @UseGuards(AdminRoleGuard)
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.computersService.remove(id);
   }

--- a/backend/src/computers/computers.module.ts
+++ b/backend/src/computers/computers.module.ts
@@ -3,6 +3,7 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AuthModule } from '@/auth/auth.module';
 import { ComponentsModule } from '@components/components.module';
 import { Computer } from '@computers/entities/computer.entity';
 import { ComputersController } from '@computers/computers.controller';
@@ -19,6 +20,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
   imports: [
     TypeOrmModule.forFeature([Computer]),
     UsersModule,
+    AuthModule,
     ComponentsModule,
   ],
   controllers: [ComputersController],

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -3,6 +3,8 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AdminRoleGuard } from '@users/guards/admin-role.guard';
+import { AuthGuard } from '@/auth/guards/auth.guard';
 import { CreateUserDto } from '@users/dtos/create-user.dto';
 import { UpdateUserDto } from '@users/dtos/update-user.dto';
 import { UserResponseDto } from '@users/dtos/user-response.dto';
@@ -21,9 +23,11 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 
 @Controller('users')
+@UseGuards(AuthGuard, AdminRoleGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,6 +3,8 @@
 // -------------------------------
 // Own Imports
 // -------------------------------
+import { AdminRoleGuard } from '@users/guards/admin-role.guard';
+import { AuthModule } from '@/auth/auth.module';
 import { User } from '@users/entities/user.entity';
 import { UsersController } from '@users/users.controller';
 import { UsersService } from '@users/users.service';
@@ -10,13 +12,13 @@ import { UsersService } from '@users/users.service';
 // -------------------------------
 // Third-Party Imports
 // -------------------------------
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => AuthModule)],
   controllers: [UsersController],
-  providers: [UsersService],
-  exports: [UsersService],
+  providers: [UsersService, AdminRoleGuard],
+  exports: [UsersService, AdminRoleGuard],
 })
 export class UsersModule {}


### PR DESCRIPTION
Register AuthGuard in AuthModule and AdminRoleGuard in UsersModule with forwardRef between AuthModule and UsersModule.

Require authentication on users, computers, components, and computers-history. Restrict mutations (POST/PATCH/DELETE on computers and components; POST on history and all user CRUD) to administrators via AdminRoleGuard.

Import AuthModule and UsersModule where controllers need guard injection.